### PR TITLE
GitHub Actions security hardening and Dependabot setup

### DIFF
--- a/.github/actions/checkout/action.yml
+++ b/.github/actions/checkout/action.yml
@@ -1,0 +1,7 @@
+name: GitHub Actions Checkout
+description: The pinned actions/checkout version
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/actions/checkout/action.yml
+++ b/.github/actions/checkout/action.yml
@@ -1,7 +1,0 @@
-name: GitHub Actions Checkout
-description: The pinned actions/checkout version
-
-runs:
-  using: composite
-  steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -54,7 +54,7 @@ runs:
           ];
           await Bun.write(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
         '
-        # don't allow dep scripts to run
+        # If we can avoid running dependency install scripts, we should do it for security
         bun install --ignore-scripts
         bun prepare
 
@@ -62,6 +62,6 @@ runs:
       id: install-deps
       shell: bash
       run: |
-        # The repo's prepare is ran manually 
+        # If we can avoid running dependency install scripts, we should do it for security
         bun install --frozen-lockfile --ignore-scripts
         bun prepare

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -54,10 +54,14 @@ runs:
           ];
           await Bun.write(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
         '
-        bun install
+        # don't allow dep scripts to run
+        bun install --ignore-scripts
+        bun prepare
 
     - name: Install Dependencies
       id: install-deps
       shell: bash
       run: |
-        bun install --frozen-lockfile
+        # The repo's prepare is ran manually 
+        bun install --frozen-lockfile --ignore-scripts
+        bun prepare

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "bun"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/publish_bun-workspaces.yml
+++ b/.github/workflows/publish_bun-workspaces.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: ./github/actions/checkout
 
       - name: Setup Project
         uses: ./.github/actions/setup
@@ -57,7 +57,7 @@ jobs:
           bun bw:build
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/publish_bun-workspaces.yml
+++ b/.github/workflows/publish_bun-workspaces.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: ./github/actions/checkout
+        uses: ./.github/actions/checkout
 
       - name: Setup Project
         uses: ./.github/actions/setup

--- a/.github/workflows/publish_bun-workspaces.yml
+++ b/.github/workflows/publish_bun-workspaces.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: ./.github/actions/checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Project
         uses: ./.github/actions/setup

--- a/.github/workflows/test_given_bun_version.yml
+++ b/.github/workflows/test_given_bun_version.yml
@@ -41,7 +41,7 @@ jobs:
     name: "Test Against Build: Bun ${{ inputs.bun_version }} on ${{ inputs.os }}"
     runs-on: ${{ inputs.os }}-${{ inputs.os_version || 'latest' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: ./github/actions/checkout
 
       - uses: ./.github/actions/setup
         with:

--- a/.github/workflows/test_given_bun_version.yml
+++ b/.github/workflows/test_given_bun_version.yml
@@ -41,7 +41,7 @@ jobs:
     name: "Test Against Build: Bun ${{ inputs.bun_version }} on ${{ inputs.os }}"
     runs-on: ${{ inputs.os }}-${{ inputs.os_version || 'latest' }}
     steps:
-      - uses: ./github/actions/checkout
+      - uses: ./.github/actions/checkout
 
       - uses: ./.github/actions/setup
         with:

--- a/.github/workflows/test_given_bun_version.yml
+++ b/.github/workflows/test_given_bun_version.yml
@@ -41,7 +41,7 @@ jobs:
     name: "Test Against Build: Bun ${{ inputs.bun_version }} on ${{ inputs.os }}"
     runs-on: ${{ inputs.os }}-${{ inputs.os_version || 'latest' }}
     steps:
-      - uses: ./.github/actions/checkout
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: ./.github/actions/setup
         with:

--- a/.github/workflows/validate_code.yml
+++ b/.github/workflows/validate_code.yml
@@ -11,7 +11,7 @@ jobs:
     name: Format Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: ./github/actions/checkout
       - name: Setup Project
         uses: ./.github/actions/setup
       - name: Format Check
@@ -22,7 +22,7 @@ jobs:
     name: Type Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: ./github/actions/checkout
       - name: Setup Project
         uses: ./.github/actions/setup
       - name: Type Check
@@ -33,7 +33,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: ./github/actions/checkout
       - name: Setup Project
         uses: ./.github/actions/setup
       - name: Lint
@@ -44,7 +44,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: ./github/actions/checkout
       - name: Setup Project
         uses: ./.github/actions/setup
       - name: Run Tests
@@ -56,7 +56,7 @@ jobs:
     name: Test Against Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: ./github/actions/checkout
       - name: Setup Project
         uses: ./.github/actions/setup
       - name: Run Tests

--- a/.github/workflows/validate_code.yml
+++ b/.github/workflows/validate_code.yml
@@ -11,7 +11,7 @@ jobs:
     name: Format Check
     runs-on: ubuntu-latest
     steps:
-      - uses: ./.github/actions/checkout
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Project
         uses: ./.github/actions/setup
       - name: Format Check
@@ -22,7 +22,7 @@ jobs:
     name: Type Check
     runs-on: ubuntu-latest
     steps:
-      - uses: ./.github/actions/checkout
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Project
         uses: ./.github/actions/setup
       - name: Type Check
@@ -33,7 +33,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: ./.github/actions/checkout
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Project
         uses: ./.github/actions/setup
       - name: Lint
@@ -44,7 +44,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: ./.github/actions/checkout
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Project
         uses: ./.github/actions/setup
       - name: Run Tests
@@ -56,7 +56,7 @@ jobs:
     name: Test Against Build
     runs-on: ubuntu-latest
     steps:
-      - uses: ./.github/actions/checkout
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Project
         uses: ./.github/actions/setup
       - name: Run Tests

--- a/.github/workflows/validate_code.yml
+++ b/.github/workflows/validate_code.yml
@@ -11,7 +11,7 @@ jobs:
     name: Format Check
     runs-on: ubuntu-latest
     steps:
-      - uses: ./github/actions/checkout
+      - uses: ./.github/actions/checkout
       - name: Setup Project
         uses: ./.github/actions/setup
       - name: Format Check
@@ -22,7 +22,7 @@ jobs:
     name: Type Check
     runs-on: ubuntu-latest
     steps:
-      - uses: ./github/actions/checkout
+      - uses: ./.github/actions/checkout
       - name: Setup Project
         uses: ./.github/actions/setup
       - name: Type Check
@@ -33,7 +33,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: ./github/actions/checkout
+      - uses: ./.github/actions/checkout
       - name: Setup Project
         uses: ./.github/actions/setup
       - name: Lint
@@ -44,7 +44,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: ./github/actions/checkout
+      - uses: ./.github/actions/checkout
       - name: Setup Project
         uses: ./.github/actions/setup
       - name: Run Tests
@@ -56,7 +56,7 @@ jobs:
     name: Test Against Build
     runs-on: ubuntu-latest
     steps:
-      - uses: ./github/actions/checkout
+      - uses: ./.github/actions/checkout
       - name: Setup Project
         uses: ./.github/actions/setup
       - name: Run Tests


### PR DESCRIPTION
* External action versions are SHA-pinned
* Add dependabot.yml
* Ignore dependency scripts on `bun install`